### PR TITLE
Fixed bug issue #27.

### DIFF
--- a/example_code/src/uint128_example/program.cpp
+++ b/example_code/src/uint128_example/program.cpp
@@ -1315,8 +1315,10 @@ void cjm::uint128::example_code::demonstrate_stream_insertion_and_extraction()
 	std::cout << newl << "This is the stream insertion and extraction demonstration." << newl;
 	{
 		std::cout << "First, we demonstrate decimal format: " << newl;
+		
 		constexpr auto expected_value = 256'368'684'943'268'121'395'391'016'720'575'361'037_u128;
-		constexpr auto narrow_text = "256,368,684,943,268,121,395,391,016,720,575,361,037"sv;
+		//commas and underscores ignored
+		constexpr auto narrow_text = "256_368_684_943_268_121_395_391_016_720_575_361_037"sv;
 		constexpr auto wide_text = L"256,368,684,943,268,121,395,391,016,720,575,361,037"sv;
 
 		std::cout << "Going to stream insert the following narrow text then extract it into a uint128_t: \"" << narrow_text << "\"." << newl;
@@ -1352,8 +1354,9 @@ void cjm::uint128::example_code::demonstrate_stream_insertion_and_extraction()
 	{
 		std::cout << "Next, we demonstrate hexadecimal format: " << newl;
 		constexpr auto expected_value = 0xc0de'd00d'ea75'dead'beef'600d'f00d_u128;
-		constexpr auto narrow_text = "0xc0ded00dea75deadbeef600df00d"sv;
-		constexpr auto wide_text =  L"0xc0ded00dea75deadbeef600df00d"sv;
+		//commas and underscores ignored
+		constexpr auto narrow_text = "0xc0de_d00d_ea75_dead_beef_600d_f00d"sv;
+		constexpr auto wide_text =  L"0xc0de,d00d,ea75,dead,beef,600d,f00d"sv;
 
 		std::cout << "Going to stream insert the following narrow text then extract it into a uint128_t: \"" << narrow_text << "\"." << newl;
 

--- a/src/cjm/numerics/uint128.hpp
+++ b/src/cjm/numerics/uint128.hpp
@@ -276,7 +276,11 @@ namespace cjm::numerics
             std::basic_string_view<Chars, CharTraits> view = trim_and_strip_me;
             std::basic_string<Chars, std::char_traits<Chars>, std::allocator<Chars>> trimmed;
             trimmed = cjm::string::trim_as_sv(view);
-            trimmed.erase(std::remove(trimmed.begin(), trimmed.end(), non_decimal_separator()[0]), trimmed.end());
+            constexpr auto non_dec_separators = non_decimal_separator();
+            for (auto separator : non_dec_separators)
+            {
+                trimmed.erase(std::remove(trimmed.begin(), trimmed.end(), separator), trimmed.end());
+            }
             return trimmed;
         }
 

--- a/uint128_test_app/src/cpp/int128_tests.cpp
+++ b/uint128_test_app/src/cpp/int128_tests.cpp
@@ -633,7 +633,10 @@ void cjm::uint128_tests::execute_uint128_tests()
     static_assert(((two_fifty_five << (15 * 8)) == all_at_ends) && ((all_at_ends >> (15 * 8)) == two_fifty_five));
     cout << "BEGINNING STANDARD TEST BATTERY." << newl;
     execute_test(execute_generate_addition_ops_rt_ser_deser_test, "generate_addition_ops_rt_ser_deser_test"sv);
-    //execute_test(parse_file_test, "parse_file_test"sv);
+
+    execute_test(execute_issue27_bug_test, "issue27_bug_test");
+
+	//execute_test(parse_file_test, "parse_file_test"sv);
     execute_test(execute_basic_test_one, "basic_test_one"sv);
     execute_test(execute_binary_operation_rt_ser_tests, "binary_operation_rt_ser_tests"sv);
     execute_test(execute_print_generated_filename_test, "print_generated_filename_test"sv);
@@ -4340,6 +4343,50 @@ void cjm::uint128_tests::execute_uintcontainer_adc_tests()
     
 }
 
+void cjm::uint128_tests::execute_issue27_bug_test()
+{
+    constexpr auto expected_value = 0xc0de'd00d'ea75'dead'beef'600d'f00d_u128;
+    constexpr auto narrow_text = "0xc0ded00dea75deadbeef600df00d"sv;
+    constexpr auto wide_text = L"0xc0de_d00dea75deadbeef600df00d"sv;
+    constexpr auto utf8_text = u8"0xc0de,d00dea75deadbeef600df00d"sv;
+    constexpr auto utf16_text = u"0xc0ded00dea75deadbeef600df00d"sv;
+    constexpr auto utf32_text = U"0xc0ded00dea75deadbeef600df00d"sv;
+
+    auto narrow_stream = cjm::string::make_throwing_sstream<char>();
+    auto wide_stream = cjm::string::make_throwing_sstream<wchar_t>();
+    auto utf8_stream = cjm::string::make_throwing_sstream<char8_t>();
+    auto utf16_stream = cjm::string::make_throwing_sstream<char16_t>();
+    auto utf32_stream = cjm::string::make_throwing_sstream<char32_t>();
+
+    uint128_t narrow_result, wide_result, utf8_result, utf16_result, utf32_result;
+	
+    cout << "Testing narrow text conversion...." << newl;
+    narrow_stream << narrow_text;
+    narrow_stream >> narrow_result;
+
+    cjm_assert(narrow_result == expected_value);
+	
+    cout << "Testing wide text conversion...." << newl;
+    wide_stream << wide_text;
+    wide_stream >> wide_result;
+    cjm_assert(wide_result == expected_value);
+
+    cout << "Testing utf8 text conversion...." << newl;
+    utf8_stream << utf8_text;
+    utf8_stream >> utf8_result;
+    cjm_assert(utf8_result == expected_value);
+
+    cout << "Testing utf16 text conversion...." << newl;
+    utf16_stream << utf16_text;
+    utf16_stream >> utf16_result;
+    cjm_assert(utf16_result == expected_value);
+
+    cout << "Testing utf32 text conversion...." << newl;
+    utf32_stream << utf32_text;
+    utf32_stream >> utf32_result;
+    cjm_assert(utf32_result == expected_value);
+}
+
 
 #ifdef CJM_HAVE_BUILTIN_128
 void cjm::uint128_tests::execute_builtin_u128fls_test_if_avail()
@@ -4358,7 +4405,7 @@ void cjm::uint128_tests::execute_builtin_u128fls_test_if_avail()
 #else
 void cjm::uint128_tests::execute_builtin_u128fls_test_if_avail()
 {
-    std::cout << "Will not test builtin_u128_fls because not available in this enviornment." << newl;
+    std::cout << "Will not test builtin_u128_fls because not available in this environment." << newl;
 }
 
 

--- a/uint128_test_app/src/headers/int128_tests.hpp
+++ b/uint128_test_app/src/headers/int128_tests.hpp
@@ -181,6 +181,8 @@ namespace cjm::uint128_tests
 
     void execute_umult_spec_tests();
     void execute_uintcontainer_adc_tests();
+
+    void execute_issue27_bug_test();
 	
     [[maybe_unused]] void print_n_static_assertions(const binary_op_u128_vect_t& op_vec, size_t n);
     [[maybe_unused]] void print_n_static_assertions(const unary_op_u128_vect_t& op_vec, size_t n);


### PR DESCRIPTION
Parsed bytes inserted into big endian array needed to be right shifted where num_digits < max_digits.  Also, restored support for underscore separator.